### PR TITLE
Prismaの依存関係を更新し、Neonデータベースアダプタを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@mastra/loggers": "^0.10.0",
         "@mastra/memory": "^0.10.1",
         "@next/eslint-plugin-next": "^15.2.1",
+        "@prisma/adapter-neon": "^6.9.0",
+        "@prisma/adapter-pg": "^6.9.0",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/ssr": "^0.4.0",
@@ -37,7 +39,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
-        "@prisma/client": "^6.5.0",
+        "@prisma/client": "^6.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -52,7 +54,7 @@
         "jiti": "^2.4.2",
         "npm": "^11.2.0",
         "prettier": "3.5.3",
-        "prisma": "^6.5.0",
+        "prisma": "^6.9.0",
         "stylelint": "^15.11.0",
         "stylelint-config-standard": "^31.0.0",
         "typescript": "^5.8.2"
@@ -2879,6 +2881,49 @@
       "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
       "license": "MIT"
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.0.tgz",
+      "integrity": "sha512-XWmEeWpBXIoksZSDN74kftfTnXFEGZ3iX8jbANWBc+ag6dsiQuvuR4LgB0WdCOKMb5AQgjqgufc0TgAsZubUYw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^22.10.2",
+        "@types/pg": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/@types/node": {
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/@types/pg": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@next/env": {
       "version": "14.2.23",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.23.tgz",
@@ -4453,10 +4498,54 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prisma/adapter-neon": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-6.9.0.tgz",
+      "integrity": "sha512-IieUWFTXB4PliGenc0MuShyLlAfO8rpWQr9T3oim/uztnvIFcz9PSia83kdrCfaNKre+MJH3GJd3bI/RvGrWWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "6.9.0",
+        "postgres-array": "3.0.4"
+      },
+      "peerDependencies": {
+        "@neondatabase/serverless": ">0.6.0 <2"
+      }
+    },
+    "node_modules/@prisma/adapter-neon/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-6.9.0.tgz",
+      "integrity": "sha512-AWCg8TvLi0VmxPzFhORebyUTmU6eCy9bviuwHqA3ZiipWHTagg/kj1D4b2oaJzXrFRFKnOiSJdFKcjODU0vu5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "6.9.0",
+        "postgres-array": "3.0.4"
+      },
+      "peerDependencies": {
+        "pg": "^8.11.3"
+      }
+    },
+    "node_modules/@prisma/adapter-pg/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@prisma/client": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.5.0.tgz",
-      "integrity": "sha512-M6w1Ql/BeiGoZmhMdAZUXHu5sz5HubyVcKukbLs3l0ELcQb8hTUJxtGEChhv4SVJ0QJlwtLnwOLgIRQhpsm9dw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4477,64 +4566,71 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.5.0.tgz",
-      "integrity": "sha512-sOH/2Go9Zer67DNFLZk6pYOHj+rumSb0VILgltkoxOjYnlLqUpHPAN826vnx8HigqnOCxj9LRhT6U7uLiIIWgw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "esbuild": ">=0.12 <1",
-        "esbuild-register": "3.6.0"
+        "jiti": "2.4.2"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.5.0.tgz",
-      "integrity": "sha512-fc/nusYBlJMzDmDepdUtH9aBsJrda2JNErP9AzuHbgUEQY0/9zQYZdNlXmKoIWENtio+qarPNe/+DQtrX5kMcQ==",
-      "dev": true,
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
       "license": "Apache-2.0"
     },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.9.0.tgz",
+      "integrity": "sha512-HtugVGw5y50drVTboKubHJeOmoUQfDZa8vJBhzgR+iZ8KfUsJuTIU20rNd7Hi/S+JdLJGJXIxzbXiQABMNArjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
+      }
+    },
     "node_modules/@prisma/engines": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.5.0.tgz",
-      "integrity": "sha512-FVPQYHgOllJklN9DUyujXvh3hFJCY0NX86sDmBErLvoZjy2OXGiZ5FNf3J/C4/RZZmCypZBYpBKEhx7b7rEsdw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0",
-        "@prisma/engines-version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
-        "@prisma/fetch-engine": "6.5.0",
-        "@prisma/get-platform": "6.5.0"
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60.tgz",
-      "integrity": "sha512-iK3EmiVGFDCmXjSpdsKGNqy9hOdLnvYBrJB61far/oP03hlIxrb04OWmDjNTwtmZ3UZdA5MCvI+f+3k2jPTflQ==",
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.5.0.tgz",
-      "integrity": "sha512-3LhYA+FXP6pqY8FLHCjewyE8pGXXJ7BxZw2rhPq+CZAhvflVzq4K8Qly3OrmOkn6wGlz79nyLQdknyCG2HBTuA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0",
-        "@prisma/engines-version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
-        "@prisma/get-platform": "6.5.0"
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.5.0.tgz",
-      "integrity": "sha512-xYcvyJwNMg2eDptBYFqFLUCfgi+wZLcj6HDMsj0Qw0irvauG4IKmkbywnqwok0B+k+W+p+jThM2DKTSmoPCkzw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0"
+        "@prisma/debug": "6.9.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -8555,19 +8651,6 @@
         "@esbuild/win32-arm64": "0.25.1",
         "@esbuild/win32-ia32": "0.25.1",
         "@esbuild/win32-x64": "0.25.1"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/escalade": {
@@ -16133,24 +16216,21 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.5.0.tgz",
-      "integrity": "sha512-yUGXmWqv5F4PByMSNbYFxke/WbnyTLjnJ5bKr8fLkcnY7U5rU9rUTh/+Fja+gOrRxEgtCbCtca94IeITj4j/pg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.5.0",
-        "@prisma/engines": "6.5.0"
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
         "node": ">=18.18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
       },
       "peerDependencies": {
         "typescript": ">=5.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:mastra": "mastra build --dir mastra",
     "dev:hcm": "hcm 'src/**/*.module.css' -w",
     "hcm": "hcm 'src/**/*.module.css'",
-    "build": "prisma generate --no-engine && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:js": "eslint --ext .ts,.tsx,.js --ignore-path .gitignore .",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@mastra/loggers": "^0.10.0",
     "@mastra/memory": "^0.10.1",
     "@next/eslint-plugin-next": "^15.2.1",
+    "@prisma/adapter-neon": "^6.9.0",
+    "@prisma/adapter-pg": "^6.9.0",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/ssr": "^0.4.0",
@@ -49,7 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
-    "@prisma/client": "^6.5.0",
+    "@prisma/client": "^6.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -64,7 +66,7 @@
     "jiti": "^2.4.2",
     "npm": "^11.2.0",
     "prettier": "3.5.3",
-    "prisma": "^6.5.0",
+    "prisma": "^6.9.0",
     "stylelint": "^15.11.0",
     "stylelint-config-standard": "^31.0.0",
     "typescript": "^5.8.2"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
 }
 
 datasource db {

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -1,11 +1,10 @@
-import { PrismaClient } from "@prisma/client/edge";
+import { prisma } from "@/lib/prisma/prisma";
 import { Hono } from "hono";
 import { handle } from "hono/vercel";
 
 export const runtime = "edge";
 
 const app = new Hono().basePath("/api");
-const prisma = new PrismaClient();
 
 app.get("/todos", async (c) => {
   const todos = await prisma.todo.findMany();

--- a/src/lib/prisma/prisma.ts
+++ b/src/lib/prisma/prisma.ts
@@ -1,0 +1,32 @@
+//参考:https://gist.github.com/kincaidoneil/bc2516111f0ec8850cd6020b8191b27b?utm_source=chatgpt.com
+
+import { neonConfig } from "@neondatabase/serverless";
+import { PrismaNeon } from "@prisma/adapter-neon";
+import { PrismaClient } from "@prisma/client";
+import { WebSocket } from "ws";
+
+// Example Supabase pooled connection string (must use Supavisor)
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL environment variable is not set");
+}
+
+const url = new URL(connectionString);
+if (url.hostname === "localhost") {
+  // Disable SSL for local connections
+  neonConfig.useSecureWebSocket = false;
+  // WebSocket proxy is hosted on `4000` locally, so add port. Does not work in production.
+  neonConfig.wsProxy = (host, port) => `${host}:${port}/v2`;
+}
+
+// Only Neon hosts support this -- non-deterministic errors otherwise
+neonConfig.pipelineConnect = false;
+
+// So it can also work in Node.js
+neonConfig.webSocketConstructor = WebSocket;
+
+const adapter = new PrismaNeon({ connectionString });
+export const prisma = new PrismaClient({
+  adapter,
+});


### PR DESCRIPTION
Prisma acclerateを剥がすために、neonのアダプタを使って無理やりedge側からprisma Clientを呼ぶためのPR